### PR TITLE
Update RequestError & Deprecated Environment 

### DIFF
--- a/Sources/Poppify/Client.swift
+++ b/Sources/Poppify/Client.swift
@@ -55,8 +55,7 @@ extension URLSession: URLSessionType {
 }
 
 /// Encapsulates various types of errors encounters when executing a request
-public enum RequestError: Error, Equatable {
-
+public enum RequestError: Error {
     /// Uable to create a valid request
     case invalidRequest
     
@@ -74,19 +73,9 @@ public enum RequestError: Error, Equatable {
     
     /// The decoding failed with the given error
     case decode(error: Error)
-    
-    var localizedDescription: String {
-        switch self {
-        case .invalidData: return "Invalid Data"                                            // No data sent
-        case .invalidResponse: return "Invalid Response"                                    // URLResponse not HTTPURLResponse
-        case .unhandledStatusCode(let code): return "Invalid Response StatusCode \(code)"   // Status Code not 2xx
-        case .response(let error): return "Response Error \(error)"                         // Error from Request
-        case .decode(let error): return "Decode Error \(error)"                             // Error from Decoder
-        case .invalidRequest:
-            return "Unable to create valid request for resource in environment"
-        }
-    }
+}
 
+extension RequestError: Equatable {
     public static func == (lhs: RequestError, rhs: RequestError) -> Bool {
         switch (lhs, rhs) {
         case (.invalidData, .invalidData),
@@ -96,6 +85,25 @@ public enum RequestError: Error, Equatable {
             (.decode(_), .decode(_)):
             return true
         default: return false
+        }
+    }
+}
+
+extension RequestError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .invalidData:
+            return NSLocalizedString("Invalid Data", comment: "No data sent")                                           // No data sent
+        case .invalidResponse:
+            return NSLocalizedString("Invalid Response", comment: "URLResponse not HTTPURLResponse")                    // URLResponse not HTTPURLResponse
+        case .unhandledStatusCode(let code):
+            return NSLocalizedString("Invalid Response StatusCode \(code)" , comment: "Status Code not 2xx")            // Status Code not 2xx
+        case .response(let error):
+            return NSLocalizedString("Response Error \(error.localizedDescription)", comment: "Error from Request")     // Error from Request
+        case .decode(let error):
+            return NSLocalizedString("Decode Error \(error.localizedDescription)" , comment: "Error from Decoder")      // Error from Decoder
+        case .invalidRequest:
+            return NSLocalizedString("Unable to create valid request for resource in environment", comment: "Error during request creation")
         }
     }
 }

--- a/Sources/Poppify/EnvironmentInfo.swift
+++ b/Sources/Poppify/EnvironmentInfo.swift
@@ -88,3 +88,37 @@ public struct EnvironmentInfo: EnvironmentType, CustomDebugStringConvertible {
         return output
     }
 }
+
+/// A simple value which conforms to `EnvironmentType` and contains a `debugDescription` for debugging purposes.
+@available(*, deprecated, renamed: "EnvironmentInfo")
+public struct Environment: EnvironmentType, CustomDebugStringConvertible {
+
+    public let scheme: HTTP.Scheme
+    public let endpoint: String
+    public let additionalHeaders: [String: String]
+    public let port: Int?
+    public let secret: Secret?
+
+    public init(scheme: HTTP.Scheme,
+                endpoint: String,
+                additionalHeaders: [String : String] = [:],
+                port: Int? = nil,
+                secret: Secret? = nil) {
+        self.scheme = scheme
+        self.endpoint = endpoint
+        self.additionalHeaders = additionalHeaders
+        self.port = port
+        self.secret = secret
+    }
+    
+    /// A textual representation of this instance, suitable for debugging.
+    ///
+    /// The values for `additionalHeaders` and `secret` are purposely omitted
+    public var debugDescription: String {
+        var output = "\(scheme.rawValue)-\(endpoint)"
+        if let port = port {
+            output += ":\(port)"
+        }
+        return output
+    }
+}

--- a/Tests/PoppifyTests/RequestErrorTests.swift
+++ b/Tests/PoppifyTests/RequestErrorTests.swift
@@ -1,0 +1,51 @@
+//
+//  RequestErrorTests.swift
+//  
+//
+//  Created by Brian Munjoma on 22/11/2023.
+//
+
+import XCTest
+@testable import Poppify
+
+final class RequestErrorTests: XCTestCase {
+    
+    func test_InvalidData_localizedDescription_isCorrect() {
+        let sut: Error = RequestError.invalidData
+        
+        XCTAssertEqual(sut.localizedDescription, "Invalid Data")
+    }
+
+    func test_InvalidResponse_localizedDescription_isCorrect() {
+        let sut: Error = RequestError.invalidResponse
+        
+        XCTAssertEqual(sut.localizedDescription, "Invalid Response")
+    }
+    
+    func test_UnhandledStatusCode_localizedDescription_isCorrect() {
+        let code = 500
+        let sut: Error = RequestError.unhandledStatusCode(code)
+        
+        XCTAssertEqual(sut.localizedDescription, "Invalid Response StatusCode \(code)")
+    }
+    
+    func test_ResponseError_localizedDescription_isCorrect() {
+        let error = NSError(domain: "domain", code: -1, userInfo: [NSLocalizedDescriptionKey:"Errored"])
+        let sut: Error = RequestError.response(error: error)
+        
+        XCTAssertEqual(sut.localizedDescription, "Response Error \(error.localizedDescription)")
+    }
+
+    func test_DecodeError_localizedDescription_isCorrect() {
+        let error = NSError(domain: "domain", code: -1, userInfo: [NSLocalizedDescriptionKey:"Errored"])
+        let sut: Error = RequestError.decode(error: error)
+        
+        XCTAssertEqual(sut.localizedDescription, "Decode Error \(error.localizedDescription)" )
+    }
+    
+    func test_InvalidRequest_localizedDescription_isCorrect() {
+        let sut: Error = RequestError.invalidRequest
+        
+        XCTAssertEqual(sut.localizedDescription, "Unable to create valid request for resource in environment")
+    }
+}


### PR DESCRIPTION
- RequestError `localizedDescription` not output the description when used as `Error`
- Deprecated `Environment` due to name clashes with `@Environment ` property wrapper