### PR TITLE
refactor/documentaion update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Clients are responsible for executing requests against a specified environment u
 ```swift
 struct CustomAsyncClient: AsyncHTTPClient {
     var environment: EnvironmentType
-    var urlSession: URLSessionType
+    var urlSession: AsyncURLSessionType
 }
 
 let client = CustomAsyncClient(
@@ -119,8 +119,8 @@ For clients conforming to `HTTPClient`, requests can be executed using completio
 ```swift
 let task = client.executeRequest(with: request) { result in
     switch result {
-    case .success(let data, let response):
-        print("Received data: \(data)")
+    case .success(let response):
+        print("Received data: \(response.data)")
     case .failure(let error):
         print(error)
     }

--- a/Sources/Poppify/Enums/HTTP.swift
+++ b/Sources/Poppify/Enums/HTTP.swift
@@ -96,7 +96,16 @@ public enum HTTP {
         /// The `DELETE` method deletes the specified resource.
         case DELETE
         
+        /// The `CONNECT` method establishes a tunnel to the server identified by the target resource.
+        case CONNECT
+
+        /// The `OPTIONS` method describes the communication options for the target resource.
+        case OPTIONS
+
         /// The `PATCH` method applies partial modifications to a resource.
         case PATCH
+
+        /// The `TRACE` method performs a message loop-back test along the path to the target resource.
+        case TRACE
     }
 }

--- a/Sources/Poppify/Enums/HeaderPrecedence.swift
+++ b/Sources/Poppify/Enums/HeaderPrecedence.swift
@@ -1,0 +1,49 @@
+//
+//  HeaderPrecedence.swift
+//  Poppify
+//
+//  Created by Brian Munjoma on 19/05/2026.
+//
+//  Copyright (c) 2023 Brian Munjoma
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+/// Controls which headers win when `request.headers` and `environment.additionalHeaders`
+/// define the same key.
+///
+/// The `environment.secret` header, if present, always takes the highest priority
+/// regardless of this setting.
+public enum HeaderPrecedence {
+
+    /// Environment headers are applied after request headers, overwriting any conflicting keys.
+    ///
+    /// Application order: request → environment → secret
+    ///
+    /// Use this when environment-wide concerns (e.g. API versioning headers) should always
+    /// override per-request values.
+    case environmentOverRequest
+
+    /// Request headers are applied after environment headers, overwriting any conflicting keys.
+    ///
+    /// Application order: environment → request → secret
+    ///
+    /// Use this when request-specific values (e.g. a custom `Content-Type`) should take
+    /// priority over environment-wide defaults.
+    case requestOverEnvironment
+}

--- a/Sources/Poppify/Enums/RequestError.swift
+++ b/Sources/Poppify/Enums/RequestError.swift
@@ -28,7 +28,7 @@ import Foundation
 
 /// Encapsulates various types of errors encounters when executing a request
 public enum RequestError: Error {
-    /// Uable to create a valid request
+    /// Unable to create a valid request
     case invalidRequest
 
     /// The `Data?` object was nil
@@ -37,7 +37,7 @@ public enum RequestError: Error {
     /// The `response` object was not a `HTTPResponse` type
     case invalidResponse
 
-    /// The requested errored with the given error
+    /// The request failed with the given error
     case response(error: Error)
 }
 

--- a/Sources/Poppify/Extensions/URLRequest+Extension.swift
+++ b/Sources/Poppify/Extensions/URLRequest+Extension.swift
@@ -27,29 +27,39 @@
 import Foundation
 
 public extension URLRequest {
-    
+
     /// Initializes a newly created URLRequest using the contents of the given request, relative to a given environment.
     /// - Parameters:
-    ///   - request: The request used to create the URL for the URLRequest
-    ///   - environment: The environment used to create the URL and fill the relevant fields of the URLRequest
-    init?(request: Requestable, in environment: EnvironmentType) {
+    ///   - request: The request used to create the URL and supply request-specific headers and body.
+    ///   - environment: The environment used to construct the base URL, additional headers, and optional secret.
+    ///   - headerPrecedence: Determines which source wins when `request.headers` and
+    ///     `environment.additionalHeaders` share the same key. Defaults to `.environmentOverRequest`.
+    ///
+    /// The `environment.secret` header, if present, is always applied last and takes the highest priority
+    /// regardless of `headerPrecedence`.
+    ///
+    /// Header application order:
+    /// - `.environmentOverRequest`: request headers → environment headers → secret
+    /// - `.requestOverEnvironment`: environment headers → request headers → secret
+    init?(request: Requestable, in environment: EnvironmentType, headerPrecedence: HeaderPrecedence = .environmentOverRequest) {
 
         guard let fullURL = request.url(using: environment) else { return nil }
         self.init(url: fullURL)
         self.httpMethod = request.method.rawValue
 
-        request.headers.forEach { (key, value) in
-            self.setValue(value, forHTTPHeaderField: key)
-        }
-
-        environment.additionalHeaders.forEach { (key, value) in
-            self.setValue(value, forHTTPHeaderField: key)
+        switch headerPrecedence {
+        case .environmentOverRequest:
+            request.headers.forEach { self.setValue($0.value, forHTTPHeaderField: $0.key) }
+            environment.additionalHeaders.forEach { self.setValue($0.value, forHTTPHeaderField: $0.key) }
+        case .requestOverEnvironment:
+            environment.additionalHeaders.forEach { self.setValue($0.value, forHTTPHeaderField: $0.key) }
+            request.headers.forEach { self.setValue($0.value, forHTTPHeaderField: $0.key) }
         }
 
         if case let .header(key, value) = environment.secret {
             self.setValue(value.rawValue, forHTTPHeaderField: key.rawValue)
         }
-        
+
         self.httpBody = request.body
     }
 }

--- a/Sources/Poppify/Models/EnvironmentInfo.swift
+++ b/Sources/Poppify/Models/EnvironmentInfo.swift
@@ -63,7 +63,7 @@ public struct EnvironmentInfo: EnvironmentType, CustomDebugStringConvertible {
     }
 }
 
-/// A simple value which conforms to `EnvironmentType` and contains a `debugDescription` for debugging purposes.
+/// Renamed to `EnvironmentInfo`.
 @available(*, unavailable, renamed: "EnvironmentInfo")
 public struct Environment: EnvironmentType, CustomDebugStringConvertible {
 

--- a/Sources/Poppify/Protocols/AsyncHTTPClient/AsyncHTTPClient.swift
+++ b/Sources/Poppify/Protocols/AsyncHTTPClient/AsyncHTTPClient.swift
@@ -9,12 +9,12 @@ import Foundation
 
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public protocol AsyncHTTPClient: AsyncHTTPClientType {
-    /// Executes a network request with the specified resource and returns a Combine publisher.
+    /// Executes a network request with the specified requestable and returns the result using Swift concurrency.
     ///
     /// - Parameters:
-    ///   - request: The resource representing the network request to be executed.
-    /// - Returns: An HTTPClientResponse containing the result of the network request.
-    /// - Throws: An error if the network request fails.
+    ///   - request: The requestable representing the network request to be executed.
+    /// - Returns: An `HTTPClientResponse` containing the raw data and HTTP response.
+    /// - Throws: A `RequestError` if the request cannot be constructed or the network call fails.
     func asyncRequest(with request: Requestable) async throws -> HTTPClientResponse
 }
 

--- a/Sources/Poppify/Protocols/AsyncHTTPClient/AsyncHTTPClientType.swift
+++ b/Sources/Poppify/Protocols/AsyncHTTPClient/AsyncHTTPClientType.swift
@@ -10,6 +10,9 @@ import Foundation
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public protocol AsyncHTTPClientType {
     /// The environment in which the HTTP client operates, containing base URLs and other configurations.
+    ///
+    /// Marked `async` to allow conforming types to resolve the environment asynchronously if needed.
+    /// Non-async stored properties satisfy this requirement automatically.
     var environment: EnvironmentType { get async }
     
     /// The session in which the request is executed. This session is responsible for managing HTTP tasks and connections.

--- a/Sources/Poppify/Protocols/EnvironmentType.swift
+++ b/Sources/Poppify/Protocols/EnvironmentType.swift
@@ -32,7 +32,9 @@ public protocol EnvironmentType {
     /// The scheme which the request will use
     var scheme: HTTP.Scheme { get }
     
-    /// The base endpoint used for the environment
+    /// The hostname for the environment, e.g. `"api.example.com"`
+    ///
+    /// Must be a bare hostname only — no scheme, port, or path component.
     var endpoint: String { get }
     
     /// Any additional headers to be sent in the request

--- a/Sources/Poppify/Protocols/Requestable.swift
+++ b/Sources/Poppify/Protocols/Requestable.swift
@@ -26,7 +26,7 @@
 
 import Foundation
 
-/// A type that is used the create a `URLRequest` with a given environment
+/// A type that is used to create a `URLRequest` with a given environment
 public protocol Requestable: CustomDebugStringConvertible {
     
     /// The HTTP method used in the request
@@ -34,28 +34,30 @@ public protocol Requestable: CustomDebugStringConvertible {
     /// When not specified, defaults to `GET`
     var method: HTTP.Method { get }
     
-    /// The path in the environment
+    /// The path component of the request URL, relative to the environment's `basePath`
+    ///
+    /// Must begin with a `/`, e.g. `"/posts"`. The final URL path is `basePath + path`.
     var path: String { get }
     
     /// The parameters used in the request
     ///
     /// When not specified, defaults to an empty array
     ///
-    ///     var parameters { return [] }
+    ///     var parameters: [URLQueryItem] { return [] }
     var parameters: [URLQueryItem] { get }
-    
+
     /// The headers specific to the request
     ///
     /// When not specified, defaults to an empty dictionary
     ///
-    ///     var headers { return [:] }
+    ///     var headers: [String: String] { return [:] }
     var headers: [String: String] { get }
-    
+
     /// The optional body for the request
     ///
     /// When not specified, defaults to `nil`
     ///
-    ///     var body { return nil }
+    ///     var body: Data? { return nil }
     var body: Data? { get }
 }
 
@@ -65,11 +67,12 @@ public extension Requestable {
     var headers: [String: String] { return [:] }
     var body: Data? { return nil }
     
-    /// Attempts to create URL for the `Requestable` object, within the given environment
+    /// Attempts to create a URL for the `Requestable` object within the given environment.
     /// - Parameter environment: The environment used to create the URL
-    /// - Returns: A valid URL object if the `Requestable` and `EnvironmentType` contain the correct values, otherwise returns `nil`
+    /// - Returns: A valid URL object if the `Requestable` and `EnvironmentType` contain correct values, otherwise `nil`
     ///
-    /// The `environment.secret` is added if it's a query item
+    /// The final URL path is formed by joining `environment.basePath` and `path`.
+    /// If `environment.secret` is a `.queryItem`, it is appended to the query string.
     func url(using environment: EnvironmentType) -> URL? {
         var urlComponents = URLComponents()
 

--- a/Sources/Poppify/Protocols/Requestable.swift
+++ b/Sources/Poppify/Protocols/Requestable.swift
@@ -59,6 +59,11 @@ public protocol Requestable: CustomDebugStringConvertible {
     ///
     ///     var body: Data? { return nil }
     var body: Data? { get }
+
+    /// Attempts to create a URL for this `Requestable` within the given environment.
+    /// - Parameter environment: The environment used to construct the base URL
+    /// - Returns: A valid URL if all components are well-formed, otherwise `nil`
+    func url(using environment: EnvironmentType) -> URL?
 }
 
 public extension Requestable {
@@ -67,12 +72,6 @@ public extension Requestable {
     var headers: [String: String] { return [:] }
     var body: Data? { return nil }
     
-    /// Attempts to create a URL for the `Requestable` object within the given environment.
-    /// - Parameter environment: The environment used to create the URL
-    /// - Returns: A valid URL object if the `Requestable` and `EnvironmentType` contain correct values, otherwise `nil`
-    ///
-    /// The final URL path is formed by joining `environment.basePath` and `path`.
-    /// If `environment.secret` is a `.queryItem`, it is appended to the query string.
     func url(using environment: EnvironmentType) -> URL? {
         var urlComponents = URLComponents()
 

--- a/Tests/PoppifyTests/ClientTests.swift
+++ b/Tests/PoppifyTests/ClientTests.swift
@@ -9,13 +9,9 @@ import Combine
 import XCTest
 @testable import Poppify
 
-private struct MockBadEnvironment: EnvironmentType {
-    var scheme: HTTP.Scheme = .secure
-    var endpoint: String = "invalid host"
-    var additionalHeaders: [String: String] = [:]
-    var port: Int? = nil
-    var basePath: String? = nil
-    var secret: Secret? = nil
+private struct MockInvalidRequestable: Requestable {
+    let path: String = "/path"
+    func url(using environment: EnvironmentType) -> URL? { return nil }
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
@@ -94,12 +90,12 @@ final class HTTPClientTests: XCTestCase {
     }
 
     func test_HTTPClient_InvalidURL_ReturnsInvalidRequestError() {
-        let badSut = MockHTTPClient(MockBadEnvironment(), session: session)
+        let invalidRequest = MockInvalidRequestable()
 
         let exp = expectation(description: "HTTPClient invalid URL")
         var receivedError: RequestError?
 
-        let task = badSut.executeRequest(with: request) { result in
+        let task = sut.executeRequest(with: invalidRequest) { result in
             if case .failure(let error) = result { receivedError = error as? RequestError }
             exp.fulfill()
         }
@@ -185,12 +181,12 @@ final class CombineHTTPClientTests: XCTestCase {
     }
 
     func test_CombineClient_InvalidURL_ReturnsInvalidRequestError() {
-        let badSut = MockCombineHTTPClient(MockBadEnvironment(), session: session)
+        let invalidRequest = MockInvalidRequestable()
 
         let exp = expectation(description: "CombineClient invalid URL")
         var receivedError: RequestError?
 
-        badSut.publisherRequest(with: request)
+        sut.publisherRequest(with: invalidRequest)
             .sink(receiveCompletion: { completion in
                 if case .failure(let error) = completion { receivedError = error as? RequestError }
                 exp.fulfill()

--- a/Tests/PoppifyTests/URLRequestTest.swift
+++ b/Tests/PoppifyTests/URLRequestTest.swift
@@ -72,9 +72,58 @@ final class SecureEnvironmentURLRequestTest: XCTestCase {
 
         XCTAssertEqual(result.httpMethod, "HEAD")
     }
+
+    func testCreateURLRequest_headerPrecedence_environmentOverRequest_environmentWins() throws {
+        let result = try XCTUnwrap(
+            URLRequest(request: MockConflictRequest(), in: MockConflictEnvironment(), headerPrecedence: .environmentOverRequest)
+        )
+        XCTAssertEqual(result.value(forHTTPHeaderField: "X-Source"), "environment")
+    }
+
+    func testCreateURLRequest_headerPrecedence_requestOverEnvironment_requestWins() throws {
+        let result = try XCTUnwrap(
+            URLRequest(request: MockConflictRequest(), in: MockConflictEnvironment(), headerPrecedence: .requestOverEnvironment)
+        )
+        XCTAssertEqual(result.value(forHTTPHeaderField: "X-Source"), "request")
+    }
+
+    func testCreateURLRequest_secretHeader_alwaysWinsRegardlessOfPrecedence() throws {
+        let result = try XCTUnwrap(
+            URLRequest(request: MockSecretConflictRequest(), in: MockSecretEnvironment(), headerPrecedence: .requestOverEnvironment)
+        )
+        XCTAssertEqual(result.value(forHTTPHeaderField: "X-API-KEY"), "from-secret")
+    }
 }
 
 private struct MockHeadRequest: Requestable {
     let path: String
     var method: HTTP.Method { .HEAD }
+}
+
+private struct MockConflictRequest: Requestable {
+    let path: String = "/path"
+    var headers: [String: String] { ["X-Source": "request"] }
+}
+
+private struct MockConflictEnvironment: EnvironmentType {
+    var scheme: HTTP.Scheme = .secure
+    var endpoint: String = "api.mock.org"
+    var additionalHeaders: [String: String] = ["X-Source": "environment"]
+    var port: Int? = nil
+    var basePath: String? = nil
+    var secret: Secret? = nil
+}
+
+private struct MockSecretConflictRequest: Requestable {
+    let path: String = "/path"
+    var headers: [String: String] { ["X-API-KEY": "from-request"] }
+}
+
+private struct MockSecretEnvironment: EnvironmentType {
+    var scheme: HTTP.Scheme = .secure
+    var endpoint: String = "api.mock.org"
+    var additionalHeaders: [String: String] = [:]
+    var port: Int? = nil
+    var basePath: String? = nil
+    var secret: Secret? = .header("X-API-KEY", value: "from-secret")
 }


### PR DESCRIPTION
# refactor/documentation-update

## Summary

- Introduced `HeaderPrecedence` enum to give callers explicit control over whether request-level or environment-level headers win when the same key is defined in both. The `environment.secret` header always takes highest priority regardless of this setting.
- Updated `URLRequest(request:in:)` to accept a `headerPrecedence` parameter (defaults to `.environmentOverRequest` to preserve existing behaviour).
- Exposed `url(using:)` as a protocol requirement on `Requestable` so consumers and mocks can override URL construction directly, replacing the previous workaround of crafting a bad `EnvironmentType`.
- Fixed two doc-comment typos in `RequestError` ("Uable" → "Unable", "errored with" → "failed with").
- Corrected the `AsyncHTTPClient` usage example in README to use `AsyncURLSessionType` (was `URLSessionType`) and updated the success-case destructuring to match the current `HTTPClientResponse` API.
- Pinned `actions/checkout` to `v6.0.2` (was `v3`).

## Changes

| Area | What changed |
|---|---|
| `Enums/HeaderPrecedence.swift` | New file — `.environmentOverRequest` / `.requestOverEnvironment` |
| `Extensions/URLRequest+Extension.swift` | `headerPrecedence` parameter added; header merge order driven by it |
| `Protocols/Requestable.swift` | `url(using:)` promoted to protocol requirement; doc-comment fixes |
| `Enums/RequestError.swift` | Two doc-comment typos corrected |
| `Tests/URLRequestTest.swift` | Three new tests covering both precedence modes and secret-header priority |
| `Tests/ClientTests.swift` | `MockBadEnvironment` replaced with `MockInvalidRequestable` (uses `url(using:)` override) |
| `README.md` | `AsyncURLSessionType` fix; `HTTPClientResponse` destructuring fix |
| `.github/workflows/build.yml` | `actions/checkout` pinned to `v6.0.2` |

## Test plan

- [ ] `swift build` passes with no warnings
- [ ] `swift test` — all existing tests green
- [ ] `testCreateURLRequest_headerPrecedence_environmentOverRequest_environmentWins` — environment header wins on conflict
- [ ] `testCreateURLRequest_headerPrecedence_requestOverEnvironment_requestWins` — request header wins on conflict
- [ ] `testCreateURLRequest_secretHeader_alwaysWinsRegardlessOfPrecedence` — secret always wins regardless of precedence setting
- [ ] `test_HTTPClient_InvalidURL_ReturnsInvalidRequestError` — still returns `.invalidRequest` via new mock approach
- [ ] `test_CombineClient_InvalidURL_ReturnsInvalidRequestError` — same for Combine client